### PR TITLE
Configurable delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,20 @@ throttledRequest.configure({
 });//This will throttle the requests so no more than 5 are made every second
 ```
 
+Or you may use a configurable throttle by providing a function that returns the next delay, in milliseconds:
+```javascript
+var request = require('request')
+,   throttledRequest = require('throttled-request')(request);
+
+throttledRequest.configure({
+  requests: 1,
+  milliseconds: function() {
+    var minSeconds = 5, maxSeconds = 15;
+    return Math.floor((Math.random() * (maxSeconds - minSeconds) + minSeconds) * 1000);  // in milliseconds
+  }
+});//This will throttle the requests so no more than 1 is made every 5 to 15 seconds (random delay)
+```
+
 Then you can use `throttledRequest` just as you use [request](https://github.com/request/request): passing a callback, or as a stream.
 
 ###Passing a callback

--- a/lib/throttled-request.js
+++ b/lib/throttled-request.js
@@ -56,6 +56,14 @@ ThrottledRequest.prototype.configure = function (config) {
   config.milliseconds ? this.config.milliseconds = config.milliseconds : void 0;
 };
 
+ThrottledRequest.prototype.throttleDelay = function() {
+  if (isFunction(this.config.milliseconds)) {
+    return this.config.milliseconds();
+  }
+
+  return this.config.milliseconds;
+};
+
 ThrottledRequest.prototype.throttleRequest = function () {
   var self = this
   ,   args = arguments
@@ -64,10 +72,12 @@ ThrottledRequest.prototype.throttleRequest = function () {
 
   //Start counting time if hasn't started already
   if (!this.startedAt) this.startedAt = Date.now();
-
-  if (Date.now() - this.startedAt >= this.config.milliseconds) {
+  if (!this.milliseconds) this.milliseconds = this.throttleDelay();
+  
+  if (Date.now() - this.startedAt >= this.milliseconds) {
     this.sentRequests = 0;
     this.startedAt = Date.now();
+    this.milliseconds = this.throttleDelay();
   };
 
   if (this.sentRequests < this.config.requests) {
@@ -94,9 +104,14 @@ ThrottledRequest.prototype.throttleRequest = function () {
 
   setTimeout(function () {
     self.throttleRequest.apply(self, args);
-  }, this.config.milliseconds - (Date.now() - this.startedAt));
+  }, this.milliseconds - (Date.now() - this.startedAt));
 
   return requestMiddleware;
 };
+
+
+function isFunction(value) {
+  return typeof value == 'function';
+}
 
 module.exports = ThrottledRequest;

--- a/lib/throttled-request.js
+++ b/lib/throttled-request.js
@@ -65,7 +65,7 @@ ThrottledRequest.prototype.throttleRequest = function () {
   //Start counting time if hasn't started already
   if (!this.startedAt) this.startedAt = Date.now();
 
-  if (Date.now() - this.startedAt > this.config.milliseconds) {
+  if (Date.now() - this.startedAt >= this.config.milliseconds) {
     this.sentRequests = 0;
     this.startedAt = Date.now();
   };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Node.js module to easily throttle HTTP requests",
   "author": "Daniel López <danypype@gmail.com>",
   "scripts": {
-    "test": "./node_modules/.bin/mocha"
+    "test": "mocha"
   },
   "main": "./lib/index.js",
   "repository": {
@@ -27,6 +27,7 @@
     "chai-spies": "^0.5.1",
     "mocha": "^2.1.0",
     "nock": "^0.52.4",
-    "request": "^2.51.0"
+    "request": "^2.51.0",
+    "sinon": "^1.12.2"
   }
 }


### PR DESCRIPTION
Allow the user to configure the throttle delay.

As an example a random delay between 5 and 15 seconds between requests.
Included example in README documentation and relevant unit test.

Use [Sinon](http://sinonjs.org/docs/) fake timers to remove test delay by simulating time moving forward.
